### PR TITLE
refactoring max length fixing the bug

### DIFF
--- a/EZNEW/DataValidation/ValidationExtensions.cs
+++ b/EZNEW/DataValidation/ValidationExtensions.cs
@@ -670,15 +670,17 @@ namespace System
         /// <param name="value">Value</param>
         /// <param name="maxLength">max length,must be greater than zero</param>
         /// <returns>Return whether the verification has passed</returns>
-        public static bool MaxLength(this object value, int maxLength)
-        {
-            if (maxLength < 1)
-            {
-                throw new ArgumentException($"{nameof(maxLength)} must be greater than zero");
-            }
-            var maxLengthAttribute = new MaxLengthAttribute(maxLength);
-            return maxLengthAttribute.IsValid(value);
-        }
+     
+      public static bool MaxLength(this string? value, int maxLength)
+{
+    if (maxLength < 1)
+        throw new ArgumentException($"{nameof(maxLength)} must be greater than zero");
+
+    if (value is null)
+        return false;
+
+    return value.Length <= maxLength;
+}
 
         #endregion
 


### PR DESCRIPTION
when i try to use the maxlength attribute it doesn't throw err if the value is not provided or it also not working if the number is excedded my change is simple i refactored the code to not depend on other attribute simple and easy that work as before throw error if not provided the value and also excedded